### PR TITLE
qemuarma9: add virtio-rng-device

### DIFF
--- a/conf/machine/qemuarma9.conf
+++ b/conf/machine/qemuarma9.conf
@@ -28,7 +28,7 @@ QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"
 QB_TAP_OPT = "-netdev tap,id=net0,ifname=@TAP@,script=no,downscript=no -device virtio-net-device,netdev=net0,mac=@MAC@"
 QB_SLIRP_OPT = "-netdev user,id=net0"
-QB_OPT_APPEND = "-show-cursor"
+QB_OPT_APPEND = "-show-cursor -device virtio-rng-device"
 QB_DTB = "zImage-vexpress-v2p-ca9.dtb"
 # Overwrite virtio-net-pci defined in oe-core/meta/classes/qemuboot.bbclass,
 # since vexpress does not support it.


### PR DESCRIPTION
When some userspace programs use syscall: getrandom(),
the system hung, because no enough entropy collected
by the kernel, we can add virtio-rng-device to avoid it.

Signed-off-by: Dengke Du <dengke.du@windriver.com>