### PR TITLE
linux-yocto_5.0.bbappend: add it

### DIFF
--- a/recipes-kernel/linux/linux-yocto_5.0.bbappend
+++ b/recipes-kernel/linux/linux-yocto_5.0.bbappend
@@ -1,0 +1,4 @@
+# WR qemuarma9 configuration, not supported in Yocto
+KBRANCH_qemuarma9 ?= "v5.0/standard/arm-versatile-926ejs"
+KERNEL_DEVICETREE_qemuarma9 = "vexpress-v2p-ca9.dtb"
+COMPATIBLE_MACHINE_qemuarma9 = "qemuarma9"


### PR DESCRIPTION
The kernel branch using 5.0, so adding the corresponding bbappend for 5.0,
the bbappend including the correct kernel branch and device tree setting.

Signed-off-by: Dengke Du <dengke.du@windriver.com>