### PR TITLE
qemuarma9: Fix runqemu boot failure in tap mode

### DIFF
--- a/conf/machine/qemuarma9.conf
+++ b/conf/machine/qemuarma9.conf
@@ -26,10 +26,10 @@ QB_KERNEL_CMDLINE_APPEND = "console=ttyAMA0,115200 console=tty"
 # vexpress does not have any PCI bus to support virtio-rng-pci,
 # We define specific virtio block device for it.
 QB_ROOTFS_OPT = "-drive id=disk0,file=@ROOTFS@,if=none,format=raw -device virtio-blk-device,drive=disk0"
-QB_TAP_OPT = "-netdev tap,id=net0,ifname=@TAP@,script=no,downscript=no -device virtio-net-device,netdev=net0,mac=@MAC@"
+QB_TAP_OPT = "-netdev tap,id=net0,ifname=@TAP@,script=no,downscript=no"
 QB_SLIRP_OPT = "-netdev user,id=net0"
 QB_OPT_APPEND = "-show-cursor -device virtio-rng-device"
 QB_DTB = "zImage-vexpress-v2p-ca9.dtb"
 # Overwrite virtio-net-pci defined in oe-core/meta/classes/qemuboot.bbclass,
 # since vexpress does not support it.
-QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0"
+QB_NETWORK_DEVICE = "-device virtio-net-device,netdev=net0,mac=@MAC@"


### PR DESCRIPTION
Fix the following boot failure caused by duplicate network device creation.

"runqemu - ERROR - Failed to run qemu: qemu-system-arm:
-device virtio-net-device,netdev=net0,mac=@MAC@:
Property 'virtio-net-device.netdev' can't take value 'net0', it's in use"

Signed-off-by: He Zhe <zhe.he@windriver.com>